### PR TITLE
Find tix files for non-Main modules

### DIFF
--- a/src/Trace/Hpc/Coveralls.hs
+++ b/src/Trace/Hpc/Coveralls.hs
@@ -70,7 +70,11 @@ toCoverageData name (Tix tixs) = do
     sources <- mapM readSource mixs
     return $ zip3 sources mixs tixs
     where readMix' tix = readMix [mixPath] (Right tix)
-          mixPath = mixDir ++ name ++ "/"
+              where mixPath = mixDir ++ dirName ++ "/"
+                    dirName = case span (/= '/') modName of
+                       (_, []) -> name
+                       (packageId, _) -> packageId
+                    TixModule modName _ _ _ = tix
           readSource (Mix filePath _ _ _ _) = readFile filePath
 
 -- | Generate coveralls json formatted code coverage from hpc coverage data


### PR DESCRIPTION
I found a case where `hpc-coveralls` couldn't find a tix file: https://travis-ci.org/maoe/influxdb-haskell/jobs/22322723#L985

HPC sometimes [puts a package ID prefix](https://github.com/ghc/ghc/blob/e81d110e7ddd381e53c3af4fbd261d29edd16725/compiler/deSugar/Coverage.lhs#L1239). In my case, the tix file for [test-suite](https://github.com/maoe/influxdb-haskell/blob/d6b5750b2d44d242be8b589a304471c592868260/influxdb.cabal#L55) is something like:

```
Tix [ TixModule "influxdb-0.0.0/Database.InfluxDB.Types" 2843817 ...
```

and `dist/hpc` directory looks like:

```
dist/hpc/mix/influxdb-0.0.0/influxdb-0.0.0/Database.InfluxDB.Decode.mix
dist/hpc/mix/influxdb-0.0.0/influxdb-0.0.0/Database.InfluxDB.Encode.mix
dist/hpc/mix/influxdb-0.0.0/influxdb-0.0.0/Database.InfluxDB.Http.mix
dist/hpc/mix/influxdb-0.0.0/influxdb-0.0.0/Database.InfluxDB.Lens.mix
dist/hpc/mix/influxdb-0.0.0/influxdb-0.0.0/Database.InfluxDB.mix
dist/hpc/mix/influxdb-0.0.0/influxdb-0.0.0/Database.InfluxDB.Stream.mix
dist/hpc/mix/influxdb-0.0.0/influxdb-0.0.0/Database.InfluxDB.Types.Internal.mix
dist/hpc/mix/influxdb-0.0.0/influxdb-0.0.0/Database.InfluxDB.Types.mix
dist/hpc/mix/test-suite/Main.mix
dist/hpc/tix/test-suite/test-suite.tix
```

I've tested the patch locally with 7.6.3 and 7.4.2, but haven't actually tried it on Travis-CI and Coveralls. It would be appreciated if you also could test it.
