### PR TITLE
Add other-modules section to fix warnings

### DIFF
--- a/hpc-coveralls.cabal
+++ b/hpc-coveralls.cabal
@@ -76,6 +76,17 @@ library
 executable hpc-coveralls
   hs-source-dirs: src
   main-is:        HpcCoverallsMain.hs
+  other-modules:
+    HpcCoverallsCmdLine
+    Trace.Hpc.Coveralls
+    Trace.Hpc.Coveralls.Cabal
+    Trace.Hpc.Coveralls.Config
+    Trace.Hpc.Coveralls.Curl
+    Trace.Hpc.Coveralls.GitInfo
+    Trace.Hpc.Coveralls.Lix
+    Trace.Hpc.Coveralls.Paths
+    Trace.Hpc.Coveralls.Types
+    Trace.Hpc.Coveralls.Util
   build-depends:
     aeson          >= 0.7.1   && <1.3,
     base           >= 4       && < 5,


### PR DESCRIPTION
This fixes warnings like the following.

```
<no location info>: warning: [-Wmissing-home-modules]
    These modules are needed for compilation but not listed in your .cabal file's other-modules: HpcCoverallsCmdLine
                                                                                                 Paths_hpc_coveralls
                                                                                                 Trace.Hpc.Coveralls
                                                                                                 Trace.Hpc.Coveralls.Cabal
                                                                                                 Trace.Hpc.Coveralls.Config
                                                                                                 Trace.Hpc.Coveralls.Curl
                                                                                                 Trace.Hpc.Coveralls.GitInfo
                                                                                                 Trace.Hpc.Coveralls.Lix
                                                                                                 Trace.Hpc.Coveralls.Paths
                                                                                                 Trace.Hpc.Coveralls.Types
                                                                                                 Trace.Hpc.Coveralls.Util
```